### PR TITLE
feat(db): add SQLModel persistence and DB-backed activities/enrollments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+sqlmodel
+sqlalchemy

--- a/src/app.py
+++ b/src/app.py
@@ -1,15 +1,18 @@
 """
 High School Management System API
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
+A FastAPI application that now persists activities and enrollments to SQLite via SQLModel.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+
+from sqlmodel import select
+from .db import init_db, get_session
+from .models import Activity, Student, Enrollment
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,63 +22,35 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+# Initialize DB and create tables
+init_db()
+
+# Seed activities on first run if empty
+with get_session() as session:
+    count = session.exec(select(Activity)).all()
+    if not count:
+        activities_seed = [
+            Activity(name="Chess Club", description="Learn strategies and compete in chess tournaments",
+                     schedule="Fridays, 3:30 PM - 5:00 PM", max_participants=12),
+            Activity(name="Programming Class", description="Learn programming fundamentals and build software projects",
+                     schedule="Tuesdays and Thursdays, 3:30 PM - 4:30 PM", max_participants=20),
+            Activity(name="Gym Class", description="Physical education and sports activities",
+                     schedule="Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM", max_participants=30),
+            Activity(name="Soccer Team", description="Join the school soccer team and compete in matches",
+                     schedule="Tuesdays and Thursdays, 4:00 PM - 5:30 PM", max_participants=22),
+            Activity(name="Basketball Team", description="Practice and play basketball with the school team",
+                     schedule="Wednesdays and Fridays, 3:30 PM - 5:00 PM", max_participants=15),
+            Activity(name="Art Club", description="Explore your creativity through painting and drawing",
+                     schedule="Thursdays, 3:30 PM - 5:00 PM", max_participants=15),
+            Activity(name="Drama Club", description="Act, direct, and produce plays and performances",
+                     schedule="Mondays and Wednesdays, 4:00 PM - 5:30 PM", max_participants=20),
+            Activity(name="Math Club", description="Solve challenging problems and participate in math competitions",
+                     schedule="Tuesdays, 3:30 PM - 4:30 PM", max_participants=10),
+            Activity(name="Debate Team", description="Develop public speaking and argumentation skills",
+                     schedule="Fridays, 4:00 PM - 5:30 PM", max_participants=12),
+        ]
+        session.add_all(activities_seed)
+        session.commit()
 
 
 @app.get("/")
@@ -85,48 +60,63 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    with get_session() as session:
+        activities = session.exec(select(Activity)).all()
+        result = {}
+        for a in activities:
+            # count participants via query
+            pcount = session.exec(select(Enrollment).where(Enrollment.activity_id == a.id)).count()
+            result[a.name] = {
+                "description": a.description,
+                "schedule": a.schedule,
+                "max_participants": a.max_participants,
+                "participants": [] if pcount == 0 else [e.student_email for e in session.exec(select(Enrollment).where(Enrollment.activity_id == a.id)).all()]
+            }
+        return result
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_session() as session:
+        activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        # check duplicates
+        existing = session.exec(select(Enrollment).where(Enrollment.activity_id == activity.id).where(Enrollment.student_email == email)).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+        pcount = session.exec(select(Enrollment).where(Enrollment.activity_id == activity.id)).count()
+        if activity.max_participants and pcount >= activity.max_participants:
+            raise HTTPException(status_code=409, detail="Activity is full")
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+        # ensure student exists
+        student = session.exec(select(Student).where(Student.email == email)).first()
+        if not student:
+            student = Student(email=email)
+            session.add(student)
+            session.commit()
+
+        enroll = Enrollment(student_email=email, activity_id=activity.id)
+        session.add(enroll)
+        session.commit()
+        return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_session() as session:
+        activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        enroll = session.exec(select(Enrollment).where(Enrollment.activity_id == activity.id).where(Enrollment.student_email == email)).first()
+        if not enroll:
+            raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+        session.delete(enroll)
+        session.commit()
+        return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,14 @@
+from sqlmodel import SQLModel, create_engine, Session
+from pathlib import Path
+
+DB_PATH = Path(__file__).parent / "data.db"
+SQL_URL = f"sqlite:///{DB_PATH}"
+engine = create_engine(SQL_URL, connect_args={"check_same_thread": False})
+
+
+def init_db():
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    return Session(engine)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,28 @@
+from typing import Optional, List
+from sqlmodel import SQLModel, Field, Relationship
+from datetime import datetime
+
+class Enrollment(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    student_email: str
+    activity_id: Optional[int] = Field(default=None, foreign_key="activity.id")
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Activity(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    description: Optional[str] = None
+    schedule: Optional[str] = None
+    max_participants: int = 0
+    participants: List[Enrollment] = Relationship(back_populates="activity")
+
+
+Enrollment.activity = Relationship(back_populates="participants")
+
+
+class Student(SQLModel, table=True):
+    email: str = Field(primary_key=True, index=True)
+    name: Optional[str] = None
+    grade: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)


### PR DESCRIPTION
This PR adds a small SQLite-backed persistence layer using SQLModel.

What changed:
- `src/models.py` — Activity, Student, Enrollment models
- `src/db.py` — DB engine, init and session helpers
- `src/app.py` — now uses DB for /activities and signup/unregister. Seeds initial activities on first run.
- `requirements.txt` updated with `sqlmodel` and `sqlalchemy`

Notes:
- I kept the public API paths unchanged. Data is now persisted in `src/data.db` by default.
- Next steps: add tests, auth, and migrations with Alembic.
